### PR TITLE
Add Feature: Hierachy shading

### DIFF
--- a/bfTriangles.py
+++ b/bfTriangles.py
@@ -43,6 +43,7 @@ class BFTriangle:
         
         # delaunay ttriangles
         self.get_delaunay_triangles(strip)
+        self._tri_label_with_joints()
 
     def get_delaunay_triangles(self, strip=1):
         # meshgrid
@@ -104,7 +105,7 @@ class BFTriangle:
         assert len(hierarchy) == self.skeleton_pts.shape[0]
         tri_color = np.zeros_like(self.img, dtype=np.uint8)
         for i in hierarchy:
-            shading = np.where(self.shading == i)[0]
+            shading = np.where(self.tri_shading == i)[0]
             for s in shading:
                 triangle = self.tri.simplices[s]
                 tri_vertices = self._keypnts[triangle][:, [1,0]]

--- a/main.py
+++ b/main.py
@@ -100,7 +100,7 @@ if __name__ == "__main__":
 		new_pins_xy = target_motion_vec_normalized[i] + skeleton_pts_origin
 		new_vertices = arap.solve(new_pins_xy)
 		triangle._keypnts = new_vertices
-		frame_result = triangle.show_result(returnResult=True)
+		frame_result = triangle.show_result_H(returnResult=True)
 		output_video.append(frame_result)
 
 	#################################


### PR DESCRIPTION
at bfTriangles.py
- show_result_H(hierarchy=None, returnResult=True)
  if no hierarchy input, then the order of display is: 0, 15, 16, 17, 18, 2, 9, 8, 11, 13, 10, 12, 14, 1, 4, 6, 3, 5, 7
before doing this, please do _tri_label_with_joints() first